### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/nikydobrev0907/f2790fc8-c78f-4dd8-845a-52853db71c9c/a8224da1-fa1e-4ebb-b96e-e0a65f5d68c3/_apis/work/boardbadge/2b150332-9a26-40e3-8266-589945ca5eed)](https://dev.azure.com/nikydobrev0907/f2790fc8-c78f-4dd8-845a-52853db71c9c/_boards/board/t/a8224da1-fa1e-4ebb-b96e-e0a65f5d68c3/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/nikydobrev0907/f2790fc8-c78f-4dd8-845a-52853db71c9c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.